### PR TITLE
change requirejs by Ember.__loader.require

### DIFF
--- a/ember-load-initializers.js
+++ b/ember-load-initializers.js
@@ -9,7 +9,7 @@ define("ember/load-initializers",
         var regex = new RegExp('^' + prefix + '\/((?:instance-)?initializers)\/');
         var getKeys = (Object.keys || Ember.keys);
 
-        getKeys(requirejs._eak_seen).map(function (moduleName) {
+        getKeys(Ember.__loader.require._eak_seen).map(function (moduleName) {
             return {
               moduleName: moduleName,
               matches: regex.exec(moduleName)


### PR DESCRIPTION
If you try to include load-initializer in Ember-project w/o EmberCLI where `requirejs` may be the global variable (if you use RequireJS as build system), you will have an exception.
`Ember.__loader.require` resolve this problem. But I don't try this for EmberCLI projects
